### PR TITLE
Increase tado API polling interval to 5 minutes

### DIFF
--- a/lib/TadoDevice.js
+++ b/lib/TadoDevice.js
@@ -3,9 +3,9 @@
 const Homey = require('homey');
 const { OAuth2Device, OAuth2Token } = require('homey-oauth2app');
 
-const POLL_INTERVAL = 20 * 1000;
-const WEATHER_INTERVAL = 2 * 60 * 1000; // 2 minute in ms
-const ZONES_INFO_INTERVAL = 60 * 1000; // for getZonesInfo() (battery status)
+const POLL_INTERVAL = 5 * 60 * 1000; // 5 minutes in ms
+const WEATHER_INTERVAL = 15 * 60 * 1000; // 15 minutes in ms
+const ZONES_INFO_INTERVAL = 5 * 60 * 1000; // 5 minutes in ms, for getZonesInfo() (battery status)
 
 class TadoDevice extends OAuth2Device {
 


### PR DESCRIPTION
Polling interval of 20 seconds causes high load on tado servers and does not provide enough value to warrant it. tado plans to introduce a rate limit to prevent such misuse of the API, therefore the polling interval needs to be increased to make sure the integration works well in the future.

Weather polling interval was increased to 15 minutes as that is the granularity on tado side anyway.